### PR TITLE
Fixing issue with annoying "->" in top bar.

### DIFF
--- a/Foreground.skin.php
+++ b/Foreground.skin.php
@@ -124,15 +124,16 @@ class foregroundTemplate extends BaseTemplate {
 
 			<ul id="top-bar-left" class="left">
 				<li class="divider show-for-small"></li>
-					<?php foreach ( $this->getSidebar() as $boxName => $box ) { if ( ($box['header'] != wfMessage( 'toolbox' )->text())  ) { ?>
-				<li class="has-dropdown active"  id='<?php echo Sanitizer::escapeId( $box['id'] ) ?>'<?php echo Linker::tooltip( $box['id'] ) ?>>
-					<a href="#"><?php echo htmlspecialchars( $box['header'] ); ?></a>
+				<?php foreach ( $this->getSidebar() as $boxName => $box ) { if ( ($box['header'] != wfMessage( 'toolbox' )->text())  ) { ?>
+					<li class="has-dropdown active"  id='<?php echo Sanitizer::escapeId( $box['id'] ) ?>'<?php echo Linker::tooltip( $box['id'] ) ?>>
+						<a href="#"><?php echo htmlspecialchars( $box['header'] ); ?></a>
 						<?php if ( is_array( $box['content'] ) ) { ?>
 							<ul class="dropdown">
 								<?php foreach ( $box['content'] as $key => $item ) { echo $this->makeListItem( $key, $item ); } ?>
 							</ul>
-								<?php } } ?>
 						<?php } ?>
+					</li>
+				<?php } } ?>
 			</ul>
 
 			<ul id="top-bar-right" class="right">


### PR DESCRIPTION
Hi there. Thank you for Foreground.

In my use of Foreground, I don't need the left dropdown menu in the top bar. Disabling it revealed a bug in which an annoying "**->**" appears in the top bar. It is caused by a missing `</li>` tag and unbalanced PHP curly brackets. This change fixes the problem.