### PR TITLE
Per https://phabricator.wikimedia.org/T187037 Wikimedia\...Warnings()…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Version 2.3.1
+* [b/c break,code] Version minor bump down to 1.31.0 required. Roll back to 1.31.0 from 1.34.0 in skin.json file as Wikimedia\suppressWarning() and Wikimedia\restoreWarning() is available from 1.30.0.
+
 ## Version 2.3.0
 * [compatibility, deprecated] Fix for deprecated wfSuppressWarnings and wfRestoreWarnings with new Wikimedia\...
 * [bug, code] Remove duplicated prepend call in foreground.js

--- a/skin.json
+++ b/skin.json
@@ -1,6 +1,6 @@
 {
 	"name": "Foreground",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"author": [
 		"Garrick Van Buren",
 		"Jamie Thingelstad",
@@ -15,7 +15,7 @@
 		"foreground": "Foreground"
 	},
 	"requires": {
-		"MediaWiki": ">= 1.34.0"
+		"MediaWiki": ">= 1.31.0"
 	},
 	"MessagesDirs": {
 		"SkinForeground": [


### PR DESCRIPTION
… is available as the replacement. Requires MW 1.31.0 is new requires not 1.34.0

This is answer to usability over LTS versions. I have tested this on MW 1.31.6 and MW 1.32. and MW 1.34.0 