### PR TITLE
Fix Actions button

### DIFF
--- a/assets/scripts/foundation/foundation.js
+++ b/assets/scripts/foundation/foundation.js
@@ -342,7 +342,7 @@
         }
       }
 
-      S(window).load(function () {
+      S(window).on('load',function () {
         S(window)
           .trigger('resize.fndtn.clearing')
           .trigger('resize.fndtn.dropdown')

--- a/assets/scripts/foundation/foundation.topbar.js
+++ b/assets/scripts/foundation/foundation.topbar.js
@@ -245,7 +245,7 @@
 
       S(window).off('.topbar').on('resize.fndtn.topbar', self.throttle(function () {
           self.resize.call(self);
-      }, 50)).trigger('resize.fndtn.topbar').load(function () {
+      }, 50)).trigger('resize.fndtn.topbar').on('load', function () {
           // Ensure that the offset is calculated after all of the pages resources have loaded
           S(this).trigger('resize.fndtn.topbar');
       });


### PR DESCRIPTION
The 'Actions' button no longer works with new mediawiki due to jQuery changes. This fixes the issue.